### PR TITLE
Issue #3: add initial PostgreSQL data layer

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -7,12 +7,22 @@ class Settings(BaseSettings):
     app_name: str = "Polymarket Arbitrage API"
     app_env: str = "development"
     api_prefix: str = ""
+    database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5432/polymarket_arbitrage"
+    database_echo: bool = False
 
     model_config = SettingsConfigDict(
         env_file="apps/api/.env",
         env_file_encoding="utf-8",
         extra="ignore",
     )
+
+    @property
+    def sqlalchemy_database_url(self) -> str:
+        if self.database_url.startswith("postgres://"):
+            return self.database_url.replace("postgres://", "postgresql+psycopg://", 1)
+        if self.database_url.startswith("postgresql://"):
+            return self.database_url.replace("postgresql://", "postgresql+psycopg://", 1)
+        return self.database_url
 
 
 @lru_cache(maxsize=1)

--- a/apps/api/db/__init__.py
+++ b/apps/api/db/__init__.py
@@ -1,0 +1,3 @@
+from apps.api.db.base import Base
+
+__all__ = ["Base"]

--- a/apps/api/db/base.py
+++ b/apps/api/db/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/apps/api/db/models.py
+++ b/apps/api/db/models.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text, UniqueConstraint, func, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from apps.api.db.base import Base
+
+
+class Market(Base):
+    __tablename__ = "markets"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    polymarket_market_id: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    question: Mapped[str] = mapped_column(Text)
+    slug: Mapped[str | None] = mapped_column(String(255), unique=True, index=True)
+    status: Mapped[str] = mapped_column(String(50), default="active", server_default=text("'active'"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    snapshots: Mapped[list["MarketSnapshot"]] = relationship(
+        back_populates="market",
+        cascade="all, delete-orphan",
+    )
+
+
+class MarketSnapshot(Base):
+    __tablename__ = "market_snapshots"
+    __table_args__ = (
+        UniqueConstraint("market_id", "captured_at", name="uq_market_snapshots_market_captured_at"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    market_id: Mapped[int] = mapped_column(ForeignKey("markets.id", ondelete="CASCADE"), index=True)
+    best_bid: Mapped[Decimal | None] = mapped_column(Numeric(10, 4))
+    best_ask: Mapped[Decimal | None] = mapped_column(Numeric(10, 4))
+    last_traded_price: Mapped[Decimal | None] = mapped_column(Numeric(10, 4))
+    bid_size: Mapped[Decimal | None] = mapped_column(Numeric(18, 4))
+    ask_size: Mapped[Decimal | None] = mapped_column(Numeric(18, 4))
+    captured_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    market: Mapped[Market] = relationship(back_populates="snapshots")

--- a/apps/api/db/session.py
+++ b/apps/api/db/session.py
@@ -1,0 +1,24 @@
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from apps.api.config.settings import get_settings
+
+settings = get_settings()
+
+engine = create_engine(
+    settings.sqlalchemy_database_url,
+    echo=settings.database_echo,
+    pool_pre_ping=True,
+)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+
+def get_db_session() -> Generator[Session, None, None]:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/apps/api/db/smoke_test.py
+++ b/apps/api/db/smoke_test.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from apps.api.db.models import Market, MarketSnapshot
+from apps.api.db.session import SessionLocal
+
+
+def main() -> None:
+    with SessionLocal() as session:
+        market = session.scalar(select(Market).where(Market.polymarket_market_id == "demo-market-1"))
+        if market is None:
+            market = Market(
+                polymarket_market_id="demo-market-1",
+                question="Will this smoke test insert and read data?",
+                slug="demo-market-1",
+            )
+            session.add(market)
+            session.flush()
+
+        snapshot = MarketSnapshot(
+            market_id=market.id,
+            best_bid=Decimal("0.4700"),
+            best_ask=Decimal("0.5200"),
+            last_traded_price=Decimal("0.5000"),
+            bid_size=Decimal("100.0000"),
+            ask_size=Decimal("120.0000"),
+            captured_at=datetime.now(timezone.utc),
+        )
+        session.add(snapshot)
+        session.commit()
+
+        stored_market = session.scalar(
+            select(Market).where(Market.polymarket_market_id == "demo-market-1")
+        )
+        stored_snapshot = session.scalar(
+            select(MarketSnapshot).where(MarketSnapshot.market_id == market.id)
+        )
+
+        print(
+            {
+                "market_id": stored_market.id if stored_market else None,
+                "snapshot_id": stored_snapshot.id if stored_snapshot else None,
+                "best_bid": str(stored_snapshot.best_bid) if stored_snapshot else None,
+            }
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,52 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from apps.api.config.settings import get_settings
+from apps.api.db.base import Base
+from apps.api.db import models  # noqa: F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.sqlalchemy_database_url)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/0001_create_markets_and_snapshots.py
+++ b/migrations/versions/0001_create_markets_and_snapshots.py
@@ -1,0 +1,58 @@
+"""create markets and market snapshots
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-04-20
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0001"
+down_revision: str | None = None
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "markets",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("polymarket_market_id", sa.String(length=255), nullable=False),
+        sa.Column("question", sa.Text(), nullable=False),
+        sa.Column("slug", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="active"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_markets_polymarket_market_id", "markets", ["polymarket_market_id"], unique=True)
+    op.create_index("ix_markets_slug", "markets", ["slug"], unique=True)
+
+    op.create_table(
+        "market_snapshots",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("market_id", sa.Integer(), nullable=False),
+        sa.Column("best_bid", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("best_ask", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("last_traded_price", sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column("bid_size", sa.Numeric(precision=18, scale=4), nullable=True),
+        sa.Column("ask_size", sa.Numeric(precision=18, scale=4), nullable=True),
+        sa.Column("captured_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["market_id"], ["markets.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("market_id", "captured_at", name="uq_market_snapshots_market_captured_at"),
+    )
+    op.create_index("ix_market_snapshots_captured_at", "market_snapshots", ["captured_at"], unique=False)
+    op.create_index("ix_market_snapshots_market_id", "market_snapshots", ["market_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_market_snapshots_market_id", table_name="market_snapshots")
+    op.drop_index("ix_market_snapshots_captured_at", table_name="market_snapshots")
+    op.drop_table("market_snapshots")
+    op.drop_index("ix_markets_slug", table_name="markets")
+    op.drop_index("ix_markets_polymarket_market_id", table_name="markets")
+    op.drop_table("markets")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 description = "Polymarket arbitrage monorepo"
 requires-python = ">=3.11"
 dependencies = [
+    "alembic>=1.14.0,<2.0.0",
     "fastapi>=0.115.0,<1.0.0",
+    "psycopg[binary]>=3.2.0,<4.0.0",
     "pydantic-settings>=2.6.0,<3.0.0",
+    "sqlalchemy>=2.0.36,<3.0.0",
     "uvicorn[standard]>=0.32.0,<1.0.0",
 ]
 


### PR DESCRIPTION
## Summary

This PR adds the minimal PostgreSQL data layer for Issue #3.

### What was added
- PostgreSQL configuration in app settings
- SQLAlchemy base, engine, session factory, and session dependency
- Initial `markets` and `market_snapshots` models
- Initial Alembic migration for those two tables only
- Isolated smoke test script for create/insert/read verification

### What was intentionally not added
- Detector logic
- KPI logic
- Dashboard logic
- Execution logic
- Any tables beyond `markets` and `market_snapshots`

### How to run locally
```bash
python -m pip install -e .
export DATABASE_URL=postgresql://USER:PASSWORD@localhost:5432/polymarket_arbitrage
alembic upgrade head
python -m apps.api.db.smoke_test
```

## Validation
- `python -m compileall apps/api migrations`
- Real local PostgreSQL verification on April 20, 2026:
  - created disposable database
  - ran `alembic upgrade head`
  - ran `python -m apps.api.db.smoke_test`
  - verified row counts in `markets` and `market_snapshots`
