### PR TITLE
Issue #5: implement basic Neg Risk detection

### DIFF
--- a/apps/api/db/models.py
+++ b/apps/api/db/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text, UniqueConstraint, func, text
+from sqlalchemy import Boolean, DateTime, ForeignKey, JSON, Numeric, String, Text, UniqueConstraint, func, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from apps.api.db.base import Base
@@ -14,6 +14,15 @@ class Market(Base):
     polymarket_market_id: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     question: Mapped[str] = mapped_column(Text)
     slug: Mapped[str | None] = mapped_column(String(255), unique=True, index=True)
+    condition_id: Mapped[str | None] = mapped_column(String(255), index=True)
+    event_id: Mapped[str | None] = mapped_column(String(255), index=True)
+    event_slug: Mapped[str | None] = mapped_column(String(255))
+    neg_risk: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=text("false"),
+        nullable=False,
+    )
     status: Mapped[str] = mapped_column(String(50), default="active", server_default=text("'active'"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -53,3 +62,39 @@ class MarketSnapshot(Base):
     )
 
     market: Mapped[Market] = relationship(back_populates="snapshots")
+
+
+class DetectedOpportunity(Base):
+    __tablename__ = "detected_opportunities"
+    __table_args__ = (
+        UniqueConstraint(
+            "event_group_key",
+            "opportunity_type",
+            "detector_version",
+            "detection_window_start",
+            name="uq_detected_opportunities_event_type_version_window",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    detected_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        index=True,
+    )
+    detection_window_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    event_group_key: Mapped[str] = mapped_column(String(255), index=True)
+    involved_market_ids: Mapped[list[int]] = mapped_column(JSON, nullable=False)
+    opportunity_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    outcome_count: Mapped[int] = mapped_column(nullable=False)
+    gross_price_sum: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False)
+    gross_gap: Mapped[Decimal] = mapped_column(Numeric(10, 4), nullable=False)
+    detector_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        default="detected",
+        server_default=text("'detected'"),
+    )
+    raw_context: Mapped[dict | None] = mapped_column(JSON)

--- a/apps/worker/detect_neg_risk.py
+++ b/apps/worker/detect_neg_risk.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import func, select
+
+from apps.api.db.models import DetectedOpportunity
+from apps.api.db.session import SessionLocal
+from apps.worker.neg_risk_detection import scan_and_persist_neg_risk_candidates
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    with SessionLocal() as session:
+        persisted = scan_and_persist_neg_risk_candidates(session)
+        total_count = session.scalar(select(func.count()).select_from(DetectedOpportunity))
+
+    logging.info(
+        "Neg Risk detection completed. persisted_candidates=%s total_detected_opportunities=%s",
+        len(persisted),
+        total_count,
+    )
+    for candidate in persisted:
+        logging.info(
+            "opportunity id=%s event_group_key=%s type=%s outcome_count=%s gross_price_sum=%s gross_gap=%s status=%s",
+            candidate.id,
+            candidate.event_group_key,
+            candidate.opportunity_type,
+            candidate.outcome_count,
+            candidate.gross_price_sum,
+            candidate.gross_gap,
+            candidate.status,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/worker/detectors/__init__.py
+++ b/apps/worker/detectors/__init__.py
@@ -1,0 +1,1 @@
+"""Detection engines for opportunity scanning."""

--- a/apps/worker/detectors/neg_risk.py
+++ b/apps/worker/detectors/neg_risk.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Iterable
+
+
+DETECTOR_VERSION = "neg_risk_v1"
+OPPORTUNITY_TYPE = "neg_risk_long_yes_bundle"
+PRICE_PRECISION = Decimal("0.0001")
+UNIT_PAYOUT = Decimal("1.0000")
+
+
+@dataclass(slots=True)
+class DetectionMarketInput:
+    market_id: int
+    polymarket_market_id: str
+    question: str
+    slug: str | None
+    condition_id: str | None
+    event_id: str | None
+    event_slug: str | None
+    neg_risk: bool
+    snapshot_id: int
+    snapshot_captured_at: datetime
+    best_bid: Decimal | None
+    best_ask: Decimal | None
+
+
+@dataclass(slots=True)
+class NegRiskCandidate:
+    detection_window_start: datetime
+    event_group_key: str
+    involved_market_ids: list[int]
+    opportunity_type: str
+    outcome_count: int
+    gross_price_sum: Decimal
+    gross_gap: Decimal
+    detector_version: str
+    raw_context: dict[str, Any]
+
+
+def detect_neg_risk_candidates(
+    rows: Iterable[DetectionMarketInput],
+    *,
+    detector_version: str = DETECTOR_VERSION,
+) -> list[NegRiskCandidate]:
+    grouped_rows: dict[str, list[DetectionMarketInput]] = defaultdict(list)
+    for row in rows:
+        if row.neg_risk is True and row.event_id:
+            grouped_rows[row.event_id].append(row)
+
+    candidates: list[NegRiskCandidate] = []
+    for event_group_key, group_rows in grouped_rows.items():
+        candidate = _detect_long_bundle_candidate(
+            event_group_key,
+            group_rows,
+            detector_version=detector_version,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+
+    return sorted(
+        candidates,
+        key=lambda candidate: (candidate.gross_gap, candidate.event_group_key),
+        reverse=True,
+    )
+
+
+def _detect_long_bundle_candidate(
+    event_group_key: str,
+    rows: list[DetectionMarketInput],
+    *,
+    detector_version: str,
+) -> NegRiskCandidate | None:
+    ordered_rows = sorted(rows, key=lambda row: row.market_id)
+    if len(ordered_rows) < 2:
+        return None
+
+    if any(not row.neg_risk for row in ordered_rows):
+        return None
+
+    if any(row.best_ask is None for row in ordered_rows):
+        return None
+
+    if any(row.condition_id is None for row in ordered_rows):
+        return None
+
+    normalized_questions = {_normalize_text(row.question) for row in ordered_rows}
+    if len(normalized_questions) != len(ordered_rows):
+        return None
+
+    distinct_conditions = {row.condition_id for row in ordered_rows}
+    if len(distinct_conditions) != len(ordered_rows):
+        return None
+
+    gross_price_sum = _quantize(sum(row.best_ask for row in ordered_rows if row.best_ask is not None))
+    gross_gap = _quantize(UNIT_PAYOUT - gross_price_sum)
+    if gross_gap <= Decimal("0"):
+        return None
+
+    return NegRiskCandidate(
+        detection_window_start=_detection_window_start(ordered_rows),
+        event_group_key=event_group_key,
+        involved_market_ids=[row.market_id for row in ordered_rows],
+        opportunity_type=OPPORTUNITY_TYPE,
+        outcome_count=len(ordered_rows),
+        gross_price_sum=gross_price_sum,
+        gross_gap=gross_gap,
+        detector_version=detector_version,
+        raw_context={
+            "pricing_basis": "latest_yes_best_ask_sum",
+            "semantic_validation_status": "pending",
+            "execution_evaluation_status": "pending",
+            "event_slug": ordered_rows[0].event_slug,
+            "markets": [
+                {
+                    "market_id": row.market_id,
+                    "polymarket_market_id": row.polymarket_market_id,
+                    "question": row.question,
+                    "slug": row.slug,
+                    "condition_id": row.condition_id,
+                    "snapshot_id": row.snapshot_id,
+                    "snapshot_captured_at": row.snapshot_captured_at.isoformat(),
+                    "best_bid": _decimal_to_string(row.best_bid),
+                    "best_ask": _decimal_to_string(row.best_ask),
+                }
+                for row in ordered_rows
+            ],
+        },
+    )
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.lower().split())
+
+
+def _decimal_to_string(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return format(_quantize(value), "f")
+
+
+def _detection_window_start(rows: list[DetectionMarketInput]) -> datetime:
+    latest_snapshot = max(row.snapshot_captured_at for row in rows)
+    return latest_snapshot.replace(second=0, microsecond=0)
+
+
+def _quantize(value: Decimal) -> Decimal:
+    return value.quantize(PRICE_PRECISION)

--- a/apps/worker/neg_risk_detection.py
+++ b/apps/worker/neg_risk_detection.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from apps.api.db.models import DetectedOpportunity, Market, MarketSnapshot
+from apps.worker.detectors.neg_risk import (
+    DETECTOR_VERSION,
+    DetectionMarketInput,
+    detect_neg_risk_candidates,
+)
+
+
+@dataclass(slots=True)
+class PersistedOpportunity:
+    id: int
+    detected_at: datetime
+    detection_window_start: datetime
+    event_group_key: str
+    involved_market_ids: list[int]
+    opportunity_type: str
+    outcome_count: int
+    gross_price_sum: Decimal
+    gross_gap: Decimal
+    detector_version: str
+    status: str
+
+
+def scan_and_persist_neg_risk_candidates(
+    session: Session,
+    *,
+    detector_version: str = DETECTOR_VERSION,
+) -> list[PersistedOpportunity]:
+    market_inputs = load_latest_market_inputs(session)
+    candidates = detect_neg_risk_candidates(market_inputs, detector_version=detector_version)
+
+    persisted: list[PersistedOpportunity] = []
+    for candidate in candidates:
+        existing = session.scalar(
+            select(DetectedOpportunity).where(
+                DetectedOpportunity.event_group_key == candidate.event_group_key,
+                DetectedOpportunity.opportunity_type == candidate.opportunity_type,
+                DetectedOpportunity.detector_version == candidate.detector_version,
+                DetectedOpportunity.detection_window_start == candidate.detection_window_start,
+            )
+        )
+        if existing is not None:
+            persisted.append(
+                PersistedOpportunity(
+                    id=existing.id,
+                    detected_at=existing.detected_at,
+                    detection_window_start=existing.detection_window_start,
+                    event_group_key=existing.event_group_key,
+                    involved_market_ids=existing.involved_market_ids,
+                    opportunity_type=existing.opportunity_type,
+                    outcome_count=existing.outcome_count,
+                    gross_price_sum=existing.gross_price_sum,
+                    gross_gap=existing.gross_gap,
+                    detector_version=existing.detector_version,
+                    status=existing.status,
+                )
+            )
+            continue
+
+        row = DetectedOpportunity(
+            detection_window_start=candidate.detection_window_start,
+            event_group_key=candidate.event_group_key,
+            involved_market_ids=candidate.involved_market_ids,
+            opportunity_type=candidate.opportunity_type,
+            outcome_count=candidate.outcome_count,
+            gross_price_sum=candidate.gross_price_sum,
+            gross_gap=candidate.gross_gap,
+            detector_version=candidate.detector_version,
+            status="detected",
+            raw_context=candidate.raw_context,
+        )
+        session.add(row)
+        session.flush()
+        persisted.append(
+            PersistedOpportunity(
+                id=row.id,
+                detected_at=row.detected_at,
+                detection_window_start=row.detection_window_start,
+                event_group_key=row.event_group_key,
+                involved_market_ids=row.involved_market_ids,
+                opportunity_type=row.opportunity_type,
+                outcome_count=row.outcome_count,
+                gross_price_sum=row.gross_price_sum,
+                gross_gap=row.gross_gap,
+                detector_version=row.detector_version,
+                status=row.status,
+            )
+        )
+
+    session.commit()
+    return persisted
+
+
+def load_latest_market_inputs(session: Session) -> list[DetectionMarketInput]:
+    ranked_snapshots = (
+        select(
+            Market.id.label("market_id"),
+            Market.polymarket_market_id.label("polymarket_market_id"),
+            Market.question.label("question"),
+            Market.slug.label("slug"),
+            Market.condition_id.label("condition_id"),
+            Market.event_id.label("event_id"),
+            Market.event_slug.label("event_slug"),
+            Market.neg_risk.label("neg_risk"),
+            MarketSnapshot.id.label("snapshot_id"),
+            MarketSnapshot.captured_at.label("snapshot_captured_at"),
+            MarketSnapshot.best_bid.label("best_bid"),
+            MarketSnapshot.best_ask.label("best_ask"),
+            func.row_number()
+            .over(
+                partition_by=MarketSnapshot.market_id,
+                order_by=(MarketSnapshot.captured_at.desc(), MarketSnapshot.id.desc()),
+            )
+            .label("snapshot_rank"),
+        )
+        .join(MarketSnapshot, MarketSnapshot.market_id == Market.id)
+        .where(Market.status == "active")
+        .subquery()
+    )
+
+    rows = session.execute(
+        select(ranked_snapshots).where(ranked_snapshots.c.snapshot_rank == 1)
+    ).mappings()
+
+    return [
+        DetectionMarketInput(
+            market_id=row["market_id"],
+            polymarket_market_id=row["polymarket_market_id"],
+            question=row["question"],
+            slug=row["slug"],
+            condition_id=row["condition_id"],
+            event_id=row["event_id"],
+            event_slug=row["event_slug"],
+            neg_risk=row["neg_risk"],
+            snapshot_id=row["snapshot_id"],
+            snapshot_captured_at=row["snapshot_captured_at"],
+            best_bid=row["best_bid"],
+            best_ask=row["best_ask"],
+        )
+        for row in rows
+    ]

--- a/migrations/versions/0002_add_detection_metadata_and_opportunities.py
+++ b/migrations/versions/0002_add_detection_metadata_and_opportunities.py
@@ -1,0 +1,69 @@
+"""add detection metadata and detected opportunities
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-20
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("markets", sa.Column("condition_id", sa.String(length=255), nullable=True))
+    op.add_column("markets", sa.Column("event_id", sa.String(length=255), nullable=True))
+    op.add_column("markets", sa.Column("event_slug", sa.String(length=255), nullable=True))
+    op.add_column(
+        "markets",
+        sa.Column("neg_risk", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.create_index("ix_markets_condition_id", "markets", ["condition_id"], unique=False)
+    op.create_index("ix_markets_event_id", "markets", ["event_id"], unique=False)
+
+    op.create_table(
+        "detected_opportunities",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("detected_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("event_group_key", sa.String(length=255), nullable=False),
+        sa.Column("involved_market_ids", sa.JSON(), nullable=False),
+        sa.Column("opportunity_type", sa.String(length=100), nullable=False),
+        sa.Column("outcome_count", sa.Integer(), nullable=False),
+        sa.Column("gross_price_sum", sa.Numeric(precision=10, scale=4), nullable=False),
+        sa.Column("gross_gap", sa.Numeric(precision=10, scale=4), nullable=False),
+        sa.Column("detector_version", sa.String(length=50), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="detected"),
+        sa.Column("raw_context", sa.JSON(), nullable=True),
+    )
+    op.create_index(
+        "ix_detected_opportunities_detected_at",
+        "detected_opportunities",
+        ["detected_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_detected_opportunities_event_group_key",
+        "detected_opportunities",
+        ["event_group_key"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_detected_opportunities_event_group_key", table_name="detected_opportunities")
+    op.drop_index("ix_detected_opportunities_detected_at", table_name="detected_opportunities")
+    op.drop_table("detected_opportunities")
+
+    op.drop_index("ix_markets_event_id", table_name="markets")
+    op.drop_index("ix_markets_condition_id", table_name="markets")
+    op.drop_column("markets", "neg_risk")
+    op.drop_column("markets", "event_slug")
+    op.drop_column("markets", "event_id")
+    op.drop_column("markets", "condition_id")

--- a/migrations/versions/0003_add_detection_window_uniqueness.py
+++ b/migrations/versions/0003_add_detection_window_uniqueness.py
@@ -1,0 +1,48 @@
+"""add detection window uniqueness for opportunities
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-20
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "detected_opportunities",
+        sa.Column("detection_window_start", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE detected_opportunities
+        SET detection_window_start = detected_at
+        WHERE detection_window_start IS NULL
+        """
+    )
+
+    with op.batch_alter_table("detected_opportunities") as batch_op:
+        batch_op.alter_column("detection_window_start", nullable=False)
+        batch_op.create_unique_constraint(
+            "uq_detected_opportunities_event_type_version_window",
+            ["event_group_key", "opportunity_type", "detector_version", "detection_window_start"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("detected_opportunities") as batch_op:
+        batch_op.drop_constraint(
+            "uq_detected_opportunities_event_type_version_window",
+            type_="unique",
+        )
+        batch_op.drop_column("detection_window_start")

--- a/tests/test_neg_risk_detector.py
+++ b/tests/test_neg_risk_detector.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+import unittest
+
+from apps.worker.detectors.neg_risk import (
+    DETECTOR_VERSION,
+    OPPORTUNITY_TYPE,
+    DetectionMarketInput,
+    detect_neg_risk_candidates,
+)
+
+
+def _market(
+    *,
+    market_id: int,
+    condition_id: str,
+    question: str,
+    best_ask: str,
+    event_id: str = "event-1",
+    neg_risk: bool = True,
+) -> DetectionMarketInput:
+    return DetectionMarketInput(
+        market_id=market_id,
+        polymarket_market_id=f"pm-{market_id}",
+        question=question,
+        slug=f"market-{market_id}",
+        condition_id=condition_id,
+        event_id=event_id,
+        event_slug="event-1",
+        neg_risk=neg_risk,
+        snapshot_id=market_id * 10,
+        snapshot_captured_at=datetime(2026, 4, 20, tzinfo=timezone.utc),
+        best_bid=Decimal("0.1000"),
+        best_ask=Decimal(best_ask),
+    )
+
+
+class NegRiskDetectorTests(unittest.TestCase):
+    def test_detects_long_bundle_when_sum_of_latest_best_asks_is_below_one(self) -> None:
+        candidates = detect_neg_risk_candidates(
+            [
+                _market(
+                    market_id=1,
+                    condition_id="condition-1",
+                    question="Will Alice win?",
+                    best_ask="0.3000",
+                ),
+                _market(
+                    market_id=2,
+                    condition_id="condition-2",
+                    question="Will Bob win?",
+                    best_ask="0.2500",
+                ),
+                _market(
+                    market_id=3,
+                    condition_id="condition-3",
+                    question="Will Carol win?",
+                    best_ask="0.2000",
+                ),
+            ]
+        )
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate.event_group_key, "event-1")
+        self.assertEqual(candidate.opportunity_type, OPPORTUNITY_TYPE)
+        self.assertEqual(candidate.outcome_count, 3)
+        self.assertEqual(candidate.gross_price_sum, Decimal("0.7500"))
+        self.assertEqual(candidate.gross_gap, Decimal("0.2500"))
+        self.assertEqual(candidate.detector_version, DETECTOR_VERSION)
+
+    def test_skips_groups_without_structurally_complete_neg_risk_metadata(self) -> None:
+        candidates = detect_neg_risk_candidates(
+            [
+                _market(
+                    market_id=1,
+                    condition_id="condition-1",
+                    question="Will Alice win?",
+                    best_ask="0.3000",
+                ),
+                _market(
+                    market_id=2,
+                    condition_id="condition-2",
+                    question="Will Bob win?",
+                    best_ask="0.2500",
+                    neg_risk=False,
+                ),
+            ]
+        )
+        self.assertEqual(candidates, [])
+
+    def test_filters_out_non_neg_risk_markets_before_grouping(self) -> None:
+        candidates = detect_neg_risk_candidates(
+            [
+                _market(
+                    market_id=1,
+                    condition_id="condition-1",
+                    question="Will Alice win?",
+                    best_ask="0.3000",
+                    event_id="event-neg",
+                    neg_risk=True,
+                ),
+                _market(
+                    market_id=2,
+                    condition_id="condition-2",
+                    question="Will Bob win?",
+                    best_ask="0.2500",
+                    event_id="event-neg",
+                    neg_risk=True,
+                ),
+                _market(
+                    market_id=3,
+                    condition_id="condition-3",
+                    question="Will Carol win?",
+                    best_ask="0.0500",
+                    event_id="event-non-neg",
+                    neg_risk=False,
+                ),
+            ]
+        )
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate.event_group_key, "event-neg")
+        self.assertEqual(candidate.gross_price_sum, Decimal("0.5500"))
+        self.assertEqual(candidate.gross_gap, Decimal("0.4500"))
+
+    def test_uses_latest_snapshot_minute_as_detection_window(self) -> None:
+        candidates = detect_neg_risk_candidates(
+            [
+                DetectionMarketInput(
+                    market_id=1,
+                    polymarket_market_id="pm-1",
+                    question="Will Alice win?",
+                    slug="market-1",
+                    condition_id="condition-1",
+                    event_id="event-1",
+                    event_slug="event-1",
+                    neg_risk=True,
+                    snapshot_id=10,
+                    snapshot_captured_at=datetime(2026, 4, 20, 12, 34, 10, tzinfo=timezone.utc),
+                    best_bid=Decimal("0.1000"),
+                    best_ask=Decimal("0.3000"),
+                ),
+                DetectionMarketInput(
+                    market_id=2,
+                    polymarket_market_id="pm-2",
+                    question="Will Bob win?",
+                    slug="market-2",
+                    condition_id="condition-2",
+                    event_id="event-1",
+                    event_slug="event-1",
+                    neg_risk=True,
+                    snapshot_id=20,
+                    snapshot_captured_at=datetime(2026, 4, 20, 12, 34, 59, tzinfo=timezone.utc),
+                    best_bid=Decimal("0.1000"),
+                    best_ask=Decimal("0.2500"),
+                ),
+            ]
+        )
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(
+            candidates[0].detection_window_start,
+            datetime(2026, 4, 20, 12, 34, 0, tzinfo=timezone.utc),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds the first Neg Risk detector for Issue #5.

### What changed
- added market metadata needed for Neg Risk grouping and gating
- added detected opportunity storage plus uniqueness by detection window
- added detector logic and a CLI entrypoint for scans
- added unit tests for gross-gap detection and neg_risk gating

### Validation
- python3 -m unittest tests.test_neg_risk_detector
- python3 -m compileall apps/api apps/worker migrations tests
- DATABASE_URL=sqlite:////tmp/pma_issue5.db alembic upgrade head
- seeded detector verification confirmed only event-neg persisted when neg_risk=true

### Scope
This PR is detector-only. It does not add execution, semantic validation, or any Issue #6 work.